### PR TITLE
Fix: avoid calling `fetch` on DowncasedHash for icalendar 2.12.1 compatibility

### DIFF
--- a/lib/icalendar/schedulable-component.rb
+++ b/lib/icalendar/schedulable-component.rb
@@ -424,7 +424,8 @@ module Icalendar
       # @note Since icalendar 2.12.1, `Icalendar::DowncasedHash` no longer delegates all
       #   methods to `Hash`. Calling `fetch` on `ical_value.ical_params` may raise
       #   `NoMethodError`. To maintain compatibility, normalize params to a plain Hash
-      #   before accessing keys.      # @param [Icalendar::Value] ical_value an ical value that (probably) supports a time zone identifier.
+      #   before accessing keys.
+      # @param [Icalendar::Value] ical_value an ical value that (probably) supports a time zone identifier.
       # @return [ActiveSupport::TimeZone, nil] the timezone referred to by the ical_value or nil.
       # @api private
       def _extract_ical_time_zone(ical_value)

--- a/lib/icalendar/schedulable-component.rb
+++ b/lib/icalendar/schedulable-component.rb
@@ -421,13 +421,23 @@ module Icalendar
 
       ##
       # Get the timezone from the given object, assuming it can be extracted from ical params.
-      # @param [Icalendar::Value] ical_value an ical value that (probably) supports a time zone identifier.
+      # @note Since icalendar 2.12.1, `Icalendar::DowncasedHash` no longer delegates all
+      #   methods to `Hash`. Calling `fetch` on `ical_value.ical_params` may raise
+      #   `NoMethodError`. To maintain compatibility, normalize params to a plain Hash
+      #   before accessing keys.      # @param [Icalendar::Value] ical_value an ical value that (probably) supports a time zone identifier.
       # @return [ActiveSupport::TimeZone, nil] the timezone referred to by the ical_value or nil.
       # @api private
       def _extract_ical_time_zone(ical_value)
         return nil unless ical_value.is_a?(Icalendar::Value)
         return nil unless ical_value.respond_to?(:ical_params)
-        ugly_tzid = ical_value.ical_params.fetch('tzid', nil)
+
+        # Normalize DowncasedHash (icalendar >= 2.12.1) to a plain Hash before lookup.
+        params = ical_value.ical_params
+        ph = params.respond_to?(:to_h) ? params.to_h : (Hash.try_convert(params) || {})
+
+        # Prefer string key, but also check symbol key for safety.
+        ugly_tzid = ph['tzid'] || ph[:tzid]
+
         return nil if ugly_tzid.nil?
         tzid = Array(ugly_tzid).first.to_s.gsub(/^(["'])|(["'])$/, '')
         ActiveSupport::TimeZone[tzid]

--- a/spec/icalendar/schedulable-component_spec.rb
+++ b/spec/icalendar/schedulable-component_spec.rb
@@ -17,6 +17,10 @@ RSpec.context 'when `using Icalendar::Schedulable`' do
       described_class.new('event_todo_or_whatsoever')
     end
 
+    let(:ical_date_with_symbol_tzid) do
+      Icalendar::Values::DateTime.new('20180101T100000', { tzid: 'America/New_York' })
+    end
+
     let(:ical_date_with_tzid) do
       Icalendar::Values::DateTime.new('20180101T100000', tzid: 'America/New_York')
     end
@@ -40,6 +44,7 @@ RSpec.context 'when `using Icalendar::Schedulable`' do
     # rubocop:disable RSpec/MultipleExpectations
     specify '._extract_ical_time_zone' do
       expect(component._extract_ical_time_zone(ical_date_with_tzid).name).to eq('America/New_York')
+      expect(component._extract_ical_time_zone(ical_date_with_symbol_tzid).name).to eq('America/New_York')
       expect(component._extract_ical_time_zone(ical_date_without_tzid)).to be_nil
       expect(component._extract_ical_time_zone(ruby_date)).to be_nil
     end


### PR DESCRIPTION
Maintain compatibility with icalendar 2.12.1 after DowncasedHash stopped delegating fetch.
Normalized params to plain Hash before accessing 'tzid'.

Context
- Since icalendar 2.12.1, `Icalendar::DowncasedHash` stopped delegating all `Hash` methods.
- This gem called `ical_value.ical_params.fetch('tzid', ...)`, which now raises NoMethodError.

Change
- Normalize `ical_value.ical_params` to a plain Hash (`to_h` / `Hash.try_convert`) and read `'tzid'` or `:tzid`.
- Minimal spec addition to assert `:tzid` works.

Notes
- On a fresh Ubuntu/macOS, unrelated specs fail due to tz/DST expectations and a check for `Icalendar::Values::Array`.
- This PR does not modify those specs.